### PR TITLE
Singleton design pattern for Engine

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -20,7 +20,7 @@ public class Main {
     public static void main(String[] args) throws InterruptedException {
 
         // Create new Gamygdala engine
-        Engine engine = new Engine(new Gamygdala());
+        Engine engine = Engine.getInstance();
 
         // Create new Agents
         Agent mario = engine.createAgent("mario");

--- a/src/main/java/gamygdala/Engine.java
+++ b/src/main/java/gamygdala/Engine.java
@@ -15,6 +15,11 @@ import decayfunction.DecayFunction;
 public class Engine {
 
     /**
+     * Singleton Engine object.
+     */
+    private static Engine engineInstance;
+
+    /**
      * Debug flag.
      */
     public static final boolean DEBUG = true;
@@ -22,26 +27,31 @@ public class Engine {
     /**
      * Gamygdala instance.
      */
-    private Gamygdala gamygdala;
+    private Gamygdala gamygdala = new Gamygdala();
 
     /**
      * Timestamp of last emotion calculation.
      */
-    private long lastMillis;
+    private long lastMillis = System.currentTimeMillis();
 
     /**
-     * Instantiate new Engine.
-     * 
-     * @param gamygdala Gamygdala instance.
+     * Empty constructor to prevent instantiating.
+     * Use Engine.getInstance() instead.
      */
-    public Engine(Gamygdala gamygdala) {
+    private Engine() {
+    }
 
-        // Store Gamygdala instance
-        this.gamygdala = gamygdala;
+    /**
+     * Get the Engine object. If no Engine has been instantiated,
+     * create a new Engine with a fresh Gamygdala instance.
+     */
+    public static synchronized Engine getInstance() {
 
-        // Record current time on creation
-        this.lastMillis = System.currentTimeMillis();
+        if (Engine.engineInstance == null) {
+            Engine.engineInstance = new Engine();
+        }
 
+        return engineInstance;
     }
 
     /**
@@ -64,7 +74,8 @@ public class Engine {
      * @param isMaintenanceGoal Whether or not this Goal is a maintenance goal.
      * @return The newly created Goal.
      */
-    public Goal createGoalForAgent(Agent agent, String goalName, double goalUtility, boolean isMaintenanceGoal) {
+    public Goal createGoalForAgent(Agent agent, String goalName, double goalUtility,
+                    boolean isMaintenanceGoal) {
         Goal goal = new Goal(goalName, goalUtility, isMaintenanceGoal);
 
         // Add Goal to Agent
@@ -157,7 +168,8 @@ public class Engine {
     public boolean setGain(double gain) {
 
         if (gain <= 0 || gain > 20) {
-            Engine.debug("[Engine.setGain] Error: " + "gain factor for appraisal integration must be between 0 and 20.");
+            Engine.debug("[Engine.setGain] Error: "
+                            + "gain factor for appraisal integration must be between 0 and 20.");
             return false;
         }
 
@@ -197,6 +209,24 @@ public class Engine {
             Engine.debug("[Engine.setDecay] DecayFunction is null.");
         }
 
+    }
+
+    /**
+     * Get the Gamygdala instance for this Engine.
+     * 
+     * @return The Gamygdala instance.
+     */
+    public Gamygdala getGamygdala() {
+        return gamygdala;
+    }
+
+    /**
+     * Set a new Gamygdala instance for this Engine.
+     * 
+     * @param gamygdala The Gamygdala instance.
+     */
+    public void setGamygdala(Gamygdala gamygdala) {
+        this.gamygdala = gamygdala;
     }
 
     /**

--- a/src/test/java/gamygdala/EngineTest.java
+++ b/src/test/java/gamygdala/EngineTest.java
@@ -2,6 +2,7 @@ package gamygdala;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -40,6 +41,17 @@ public class EngineTest {
         engine = null;
     }
 
+    @Test
+    public void testSingleton() {
+        
+        // Create "new" Engine instance
+        Engine engine2 = Engine.getInstance();
+        
+        // Verify that it's the same object
+        assertTrue(engine == engine2);
+        
+    }
+    
     @Test
     public void testCreateAgent() {
 
@@ -148,5 +160,18 @@ public class EngineTest {
         verify(gamygdala).setDecayFactor(10d);
         verify(gamygdala).setDecayFunction(df);
 
+    }
+    
+    @Test
+    public void testGetSetGamygdala() {
+        
+        assertEquals(gamygdala, engine.getGamygdala());
+        
+        Gamygdala gam = new Gamygdala();
+        assertNotEquals(engine.getGamygdala(), gam);
+        
+        engine.setGamygdala(gam);
+        assertEquals(gam, engine.getGamygdala());
+        
     }
 }

--- a/src/test/java/gamygdala/EngineTest.java
+++ b/src/test/java/gamygdala/EngineTest.java
@@ -30,7 +30,8 @@ public class EngineTest {
     @Before
     public void setUp() {
         gamygdala = mock(Gamygdala.class);
-        engine = new Engine(gamygdala);
+        engine = Engine.getInstance();
+        engine.setGamygdala(gamygdala);
     }
 
     @After


### PR DESCRIPTION
I've implemented the Singleton design pattern for the Engine class. This way, the Engine object does not have to be stored anywhere, but can be called at any time with ```Engine.getInstance()```. This also prevents bugs caused by two or more different Engines in one implementation (which are hard to track down).

Fixes #28.