### PR TITLE
Fix Belief constructor

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -4,6 +4,7 @@ import agent.Agent;
 import data.Belief;
 import data.Goal;
 import decayfunction.ExponentialDecay;
+import exception.GoalCongruenceMapException;
 import gamygdala.Engine;
 import gamygdala.Gamygdala;
 
@@ -16,8 +17,9 @@ public class Main {
      * Run test.
      * 
      * @throws InterruptedException
+     * @throws GoalCongruenceMapException 
      */
-    public static void main(String[] args) throws InterruptedException {
+    public static void main(String[] args) throws InterruptedException, GoalCongruenceMapException {
 
         // Create new Gamygdala engine
         Engine engine = Engine.getInstance();
@@ -48,6 +50,7 @@ public class Main {
         goalCongruences.add(0.8);
 
         engine.appraise(new Belief(1, bowser, affectedGoals, goalCongruences, true));
+        
         engine.printAllEmotions(false);
 
         Thread.sleep(1000L);

--- a/src/main/java/data/Belief.java
+++ b/src/main/java/data/Belief.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 
 import agent.Agent;
-import gamygdala.Engine;
+import exception.GoalCongruenceMapException;
 
 /**
  * A Belief contains information about events (Goals) and the amount of positive
@@ -48,8 +48,10 @@ public class Belief {
      *            goals provided, i.e, it will add or subtract this belief's
      *            likelihood*congruence from the goal likelihood instead of
      *            using the belief as "state" defining the absolute likelihood
+     * @throws GoalCongruenceMapException
      */
-    public Belief(double likelihood, Agent agent, ArrayList<Goal> affectedGoals, ArrayList<Double> goalCongruences, boolean isIncremental) {
+    public Belief(double likelihood, Agent agent, ArrayList<Goal> affectedGoals, ArrayList<Double> goalCongruences,
+            boolean isIncremental) throws GoalCongruenceMapException {
         this.isIncremental = isIncremental;
 
         this.likelihood = Math.min(1, Math.max(-1, likelihood));
@@ -58,8 +60,8 @@ public class Belief {
         this.goalCongruenceMap = new HashMap<Goal, Double>();
 
         if (affectedGoals.size() != goalCongruences.size()) {
-            Engine.debug("Error: the congruence list is not of the same size " + "as the affected goal list.");
-            return;
+            throw new GoalCongruenceMapException(
+                    "Error: the congruence list does not have the same size as the affected goal list.");
         }
 
         // Add goals and congruences to Map.
@@ -109,7 +111,8 @@ public class Belief {
      * Return string representation of Belief.
      */
     public String toString() {
-        String str = "<Belief[CausalAgent = " + causalAgent + ", likelihood = " + likelihood + ", incremental = " + isIncremental + "]>";
+        String str = "<Belief[CausalAgent = " + causalAgent + ", likelihood = " + likelihood + ", incremental = "
+                + isIncremental + "]>";
         return str;
     }
 

--- a/src/main/java/exception/GoalCongruenceMapException.java
+++ b/src/main/java/exception/GoalCongruenceMapException.java
@@ -1,0 +1,14 @@
+package exception;
+
+public class GoalCongruenceMapException extends Exception {
+
+    /**
+     * 
+     */
+    private static final long serialVersionUID = 1706142455682560064L;
+    
+    public GoalCongruenceMapException(String exception) {
+        super(exception);
+    }
+    
+}

--- a/src/test/java/data/BeliefTest.java
+++ b/src/test/java/data/BeliefTest.java
@@ -7,6 +7,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import exception.GoalCongruenceMapException;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -23,7 +25,7 @@ public class BeliefTest {
     ArrayList<Double> goalCongruence;
 
     @Before
-    public void setUp() {
+    public void setUp() throws GoalCongruenceMapException {
         a = new Agent("TestAgent");
         goal = new Goal("TestGoal", .2, true);
 
@@ -52,6 +54,14 @@ public class BeliefTest {
         goalCongruenceTestMap.put(goal, .5);
 
         assertEquals(goalCongruenceTestMap, belief.getGoalCongruenceMap());
+    }
+    
+    @Test(expected=GoalCongruenceMapException.class)
+    public void testException() throws GoalCongruenceMapException {
+        
+        goalCongruence.add(.59);
+        Belief belief_exception = new Belief(.8, new Agent(""), affectedGoals, goalCongruence, true);
+
     }
 
     @Test

--- a/src/test/java/gamygdala/GamygdalaTest.java
+++ b/src/test/java/gamygdala/GamygdalaTest.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import agent.Agent;
 import data.Belief;
 import data.Goal;
+import exception.GoalCongruenceMapException;
 
 /**
  * Tests for the core Gamygdala functionality.
@@ -54,7 +55,7 @@ public class GamygdalaTest {
     }
 
     @Test
-    public void testAppraiseAffectedAgent() {
+    public void testAppraiseAffectedAgent() throws GoalCongruenceMapException {
 
         // Set-up environment (two agents with one goal)
         Agent agent1 = new Agent("TestAgent_1");


### PR DESCRIPTION
The ```Belief``` constructor contained a return statement. This should abort construction, but in practice just skipped the remaining statements. The ```Belief``` object was then incorrectly instantiated.

This is fixed by creating a new Exception to handle this particular purpose.
Fixes #34.